### PR TITLE
Accept py03 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tracing-core = "0.1"
 tracing-serde = "0.1"
 serde_json = "1.0"
 
-pyo3 = { version = "0.22.3" }
+pyo3 = { version = ">=0.22.3, <= 0.23.3" }
 
 [dev-dependencies]
 tracing = "0.1"


### PR DESCRIPTION
I was trying to use this and was relying on some new features in 0.23. This updates `Cargo.toml` to accept 0.23 as well. Builds as expected on 0.23 now. I'm not entirely sure on the syntax of the versioning, so feel free to make changes and merge as well. Thought it'd at least be valuable to know that it works as expected for 0.23.